### PR TITLE
don't fail if the gamepad object is null

### DIFF
--- a/app/js/intro.js
+++ b/app/js/intro.js
@@ -84,7 +84,9 @@ function checkGamepad() {
 	} else {
 		gamepads = navigator.getGamepads();
 		for ( gamepadIndex=0; gamepadIndex < gamepads.length; gamepadIndex++ ) {
-			if ( ( typeof gamepads[gamepadIndex] == 'object' ) && ( typeof gamepads[gamepadIndex].buttons == 'object' ) ) {
+			if ( 	gamepads[gamepadIndex] &&
+				( typeof gamepads[gamepadIndex] == 'object' ) &&
+				( typeof gamepads[gamepadIndex].buttons == 'object' ) ) {
 				gamepadButtons = gamepads[gamepadIndex].buttons.length;
 				if ( typeof gamepads[gamepadIndex].axes == 'object' ) {
 					gamepadAxes = gamepads[gamepadIndex].axes.length;


### PR DESCRIPTION
Of course, I don't know why browsers bother giving us null in this case.
